### PR TITLE
Remove `--skip-bundle` flag

### DIFF
--- a/rails_new
+++ b/rails_new
@@ -13,9 +13,9 @@ ensure
 end
 
 def rails_new(version, flag)
-  return "rails _#{version}_ new . --#{flag} --skip-bundle" if flag
+  return "rails _#{version}_ new . --#{flag}" if flag
 
-  "rails _#{version}_ new . --skip-bundle"
+  "rails _#{version}_ new ."
 end
 
 def run(command)


### PR DESCRIPTION
To reduce the execution time, `-skip-bundle` was given, but if it is given,
the actual package of the node to be used cannot be recognized, so the flag
should be removed.